### PR TITLE
Add reusable YAML configuration manager singleton

### DIFF
--- a/configuration/README.md
+++ b/configuration/README.md
@@ -1,0 +1,79 @@
+# Configuration Manager
+
+This module provides a reusable configuration loader for Nautodog. The
+`ConfigManager` class centralises the parsing of YAML configuration files and
+makes the configuration data available throughout the project via a
+thread-safe singleton.
+
+## Key capabilities
+
+- **Single initialization** – The configuration file is parsed exactly once per
+  process. Subsequent calls to `ConfigManager.instance()` re-use the cached
+  configuration.
+- **Universal YAML support** – The loader delegates parsing to `ruamel.yaml`,
+  allowing complex YAML structures including nested mappings and repeated
+  elements.
+- **Dot-path accessors** – `ConfigManager.get()` accepts dotted key paths to
+  simplify access to deeply nested configuration entries, including list
+  indices (e.g., `service.endpoints.0.url`).
+- **Undefined key tracking** – Every attempt to read an undefined key is stored
+  and can be inspected with `ConfigManager.list_missing_keys()`.
+- **Hard reload** – Call `ConfigManager.initialize(path, force_reload=True)` or
+  `ConfigManager.instance().reload()` to refresh the in-memory configuration
+  after editing the YAML file.
+- **Configuration introspection** – Use `ConfigManager.print_configuration()` or
+  `ConfigManager.as_yaml()` to inspect the current configuration state.
+
+## Usage
+
+```python
+from pathlib import Path
+from configuration.config_manager import ConfigManager
+
+# Initialize once at application start-up.
+ConfigManager.initialize(Path("config.yaml"))
+
+# Retrieve the singleton anywhere in the codebase.
+config = ConfigManager.instance()
+
+database_url = config.get("database.primary.url")
+retry_count = config.get("service.retries", default=3)
+
+# Examine undefined accesses (if any).
+for missing in config.list_missing_keys():
+    print(f"Missing key: {missing.path} (attempted {missing.attempts} times)")
+
+# Refresh the configuration when a forced update is required.
+config.reload()
+
+# Print the currently loaded configuration.
+config.print_configuration()
+```
+
+## Suggested future enhancements
+
+The following features may be useful as the configuration manager is adopted
+across the project:
+
+1. **Environment variable overrides** – Allow selected configuration values to
+   be overridden by environment variables to simplify containerized or cloud
+   deployments.
+2. **Schema validation** – Integrate with a validation library (e.g.
+   `pydantic` or `jsonschema`) to ensure configuration files adhere to an
+   expected structure before being accepted.
+3. **Change notifications** – Provide hooks or callbacks that trigger when the
+   configuration is reloaded so dependent components can react to updates.
+4. **File watching** – Monitor the configuration file for modifications and
+   reload automatically, optionally debounced to avoid repeated reloads.
+5. **Secrets management integration** – Support fetching sensitive values from
+   secret stores (such as AWS Secrets Manager or HashiCorp Vault) referenced in
+   the YAML file.
+
+## Testing
+
+A dedicated unit test (`tests/test_config_manager.py`) exercises the most common
+usage scenarios. Run the test suite with:
+
+```bash
+pytest tests/test_config_manager.py
+```

--- a/configuration/__init__.py
+++ b/configuration/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration package exposing the ConfigManager singleton."""
+
+from .config_manager import ConfigManager, MissingKey
+
+__all__ = ["ConfigManager", "MissingKey"]

--- a/configuration/config_manager.py
+++ b/configuration/config_manager.py
@@ -1,0 +1,219 @@
+"""Configuration management utilities for nautodog.
+
+This module exposes the :class:`ConfigManager` singleton, which centralizes
+loading and accessing YAML-based configuration files across the project. The
+manager automatically parses the target configuration file into memory and
+provides dot-notation access helpers, facilities to inspect undefined keys that
+were requested by the application, and tools to refresh the configuration when a
+hard update is required.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from io import StringIO
+import sys
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, TextIO, Union
+
+from ruamel.yaml import YAML
+
+
+_UNSET = object()
+
+
+def _convert_to_builtin(value: Any) -> Any:
+    """Recursively convert ruamel.yaml containers into built-in Python types."""
+
+    if isinstance(value, MutableMapping):
+        return {key: _convert_to_builtin(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_convert_to_builtin(item) for item in value]
+    return value
+
+
+def _ensure_mapping(node: Any) -> MutableMapping[str, Any]:
+    """Return *node* if it is mapping-like, otherwise raise ``TypeError``."""
+
+    if isinstance(node, MutableMapping):
+        return node
+    raise TypeError(
+        "Configuration root must be a mapping/dictionary; got " f"{type(node)!r}"
+    )
+
+
+@dataclass(frozen=True)
+class MissingKey:
+    """Representation of a missing configuration key access."""
+
+    path: str
+    attempts: int
+
+
+class ConfigManager:
+    """Singleton loader for YAML configuration files."""
+
+    _instance: Optional["ConfigManager"] = None
+    _lock: RLock = RLock()
+
+    def __init__(self, config_path: Path) -> None:
+        raise RuntimeError(
+            "Direct instantiation is not supported. Use ConfigManager.initialize()."
+        )
+
+    @classmethod
+    def initialize(
+        cls,
+        config_path: Union[str, Path],
+        *,
+        force_reload: bool = False,
+    ) -> "ConfigManager":
+        """Initialize the singleton with *config_path* if not already done."""
+
+        resolved_path = Path(config_path).expanduser().resolve()
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._config_path = resolved_path  # type: ignore[attr-defined]
+                cls._instance._yaml = YAML(typ="safe")  # type: ignore[attr-defined]
+                cls._instance._yaml.default_flow_style = False  # type: ignore[attr-defined]
+                cls._instance._missing: Dict[str, int] = {}  # type: ignore[attr-defined]
+                cls._instance._config: MutableMapping[str, Any] = {}  # type: ignore[attr-defined]
+                cls._instance._last_loaded: Optional[datetime] = None  # type: ignore[attr-defined]
+                cls._instance._load()  # type: ignore[attr-defined]
+            else:
+                if resolved_path != cls._instance._config_path and not force_reload:  # type: ignore[attr-defined]
+                    raise ValueError(
+                        "Configuration already initialized with a different file. "
+                        "Use force_reload=True to override."
+                    )
+                cls._instance._config_path = resolved_path  # type: ignore[attr-defined]
+                if force_reload:
+                    cls._instance.reload()
+        return cls._instance
+
+    @classmethod
+    def instance(cls) -> "ConfigManager":
+        """Return the active singleton instance."""
+
+        with cls._lock:
+            if cls._instance is None:
+                raise RuntimeError(
+                    "ConfigManager is not initialized. Call ConfigManager.initialize() first."
+                )
+            return cls._instance
+
+    def _load(self) -> None:
+        """Load the YAML configuration into memory."""
+
+        config_path: Path = self._config_path  # type: ignore[attr-defined]
+        yaml_loader: YAML = self._yaml  # type: ignore[attr-defined]
+
+        if not config_path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+        with config_path.open("r", encoding="utf-8") as file:
+            data = yaml_loader.load(file) or {}
+
+        mapping = _ensure_mapping(data)
+        self._config = mapping  # type: ignore[attr-defined]
+        self._missing = {}  # type: ignore[attr-defined]
+        self._last_loaded = datetime.now(timezone.utc)  # type: ignore[attr-defined]
+
+    # Public API -----------------------------------------------------------------
+    @property
+    def path(self) -> Path:
+        """Return the path of the configuration file."""
+
+        return self._config_path  # type: ignore[attr-defined]
+
+    @property
+    def last_loaded(self) -> Optional[datetime]:
+        """Return the UTC timestamp of the last successful load."""
+
+        return self._last_loaded  # type: ignore[attr-defined]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a deep copy of the configuration mapping as plain Python objects."""
+
+        return _convert_to_builtin(self._config)  # type: ignore[attr-defined]
+
+    def reload(self) -> None:
+        """Force a reload of the configuration file from disk."""
+
+        with self._lock:
+            self._load()
+
+    def get(
+        self,
+        key_path: str,
+        default: Any = _UNSET,
+        *,
+        raise_if_missing: bool = False,
+        record_missing: bool = True,
+    ) -> Any:
+        """Retrieve a configuration value using a dotted path."""
+
+        value = self._config  # type: ignore[attr-defined]
+        segments = [segment for segment in key_path.split(".") if segment]
+        for segment in segments:
+            if isinstance(value, MutableMapping) and segment in value:
+                value = value[segment]
+            elif isinstance(value, list):
+                try:
+                    index = int(segment)
+                except ValueError:
+                    if record_missing:
+                        self._missing[key_path] = self._missing.get(key_path, 0) + 1  # type: ignore[attr-defined]
+                    if raise_if_missing or default is _UNSET:
+                        raise KeyError(
+                            f"Configuration list index '{segment}' is not an integer for path '{key_path}'"
+                        )
+                    return default
+                if 0 <= index < len(value):
+                    value = value[index]
+                else:
+                    if record_missing:
+                        self._missing[key_path] = self._missing.get(key_path, 0) + 1  # type: ignore[attr-defined]
+                    if raise_if_missing or default is _UNSET:
+                        raise KeyError(
+                            f"Configuration list index '{segment}' out of range for path '{key_path}'"
+                        )
+                    return default
+            else:
+                if record_missing:
+                    self._missing[key_path] = self._missing.get(key_path, 0) + 1  # type: ignore[attr-defined]
+                if raise_if_missing or default is _UNSET:
+                    raise KeyError(f"Configuration key '{key_path}' is not defined")
+                return default
+        return value
+
+    def list_missing_keys(self) -> List[MissingKey]:
+        """Return a list of missing key accesses observed so far."""
+
+        return [MissingKey(path=path, attempts=count) for path, count in sorted(self._missing.items())]  # type: ignore[attr-defined]
+
+    def iter_items(self) -> Iterable[tuple[str, Any]]:
+        """Iterate over top-level key/value pairs."""
+
+        return self._config.items()  # type: ignore[attr-defined]
+
+    def print_configuration(self, stream: TextIO = sys.stdout) -> None:
+        """Print the current configuration to *stream* (defaults to stdout)."""
+
+        yaml_dumper = YAML()
+        yaml_dumper.default_flow_style = False
+        yaml_dumper.dump(self._config, stream)  # type: ignore[attr-defined]
+
+    def as_yaml(self) -> str:
+        """Return the configuration serialized as YAML text."""
+
+        yaml_dumper = YAML()
+        yaml_dumper.default_flow_style = False
+        buffer = StringIO()
+        yaml_dumper.dump(self._config, buffer)  # type: ignore[attr-defined]
+        return buffer.getvalue()
+
+
+__all__ = ["ConfigManager", "MissingKey"]

--- a/tests/data/config_sample.yaml
+++ b/tests/data/config_sample.yaml
@@ -1,0 +1,24 @@
+service:
+  name: nautodog
+  retries: 5
+  endpoints:
+    - url: https://api.example.com
+      timeout: 10
+    - url: https://api.backup.example.com
+      timeout: 20
+database:
+  primary:
+    host: db.example.com
+    port: 5432
+    credentials:
+      username: admin
+      password: secret
+  replicas:
+    - host: replica1.example.com
+      port: 5432
+    - host: replica2.example.com
+      port: 5432
+features:
+  enabled:
+    logging: true
+    tracing: false

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from configuration.config_manager import ConfigManager
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    # Ensure each test starts with a clean singleton instance.
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    yield
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Path:
+    source = Path(__file__).parent / "data" / "config_sample.yaml"
+    destination = tmp_path / "config.yaml"
+    destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return destination
+
+
+def test_singleton_initialization(config_file: Path) -> None:
+    first = ConfigManager.initialize(config_file)
+    second = ConfigManager.initialize(config_file)
+    assert first is second
+
+
+def test_get_nested_value_and_missing_tracking(config_file: Path) -> None:
+    manager = ConfigManager.initialize(config_file)
+    assert manager.get("database.primary.credentials.username") == "admin"
+    assert manager.get("service.retries") == 5
+    assert manager.get("service.endpoints.0.timeout") == 10
+
+    # Request an undefined key and verify it is tracked.
+    with pytest.raises(KeyError):
+        manager.get("service.unknown", raise_if_missing=True)
+
+    missing_entries = manager.list_missing_keys()
+    assert len(missing_entries) == 1
+    assert missing_entries[0].path == "service.unknown"
+    assert missing_entries[0].attempts == 1
+
+
+def test_reload_updates_configuration(config_file: Path) -> None:
+    manager = ConfigManager.initialize(config_file)
+    assert manager.get("service.retries") == 5
+
+    # Modify the underlying file and ensure reload picks up the change.
+    yaml = YAML()
+    config_data = yaml.load(config_file.read_text(encoding="utf-8"))
+    config_data["service"]["retries"] = 7
+    with config_file.open("w", encoding="utf-8") as handle:
+        yaml.dump(config_data, handle)
+
+    manager.reload()
+    assert manager.get("service.retries") == 7
+
+
+def test_to_dict_returns_plain_objects(config_file: Path) -> None:
+    manager = ConfigManager.initialize(config_file)
+    plain = manager.to_dict()
+    assert isinstance(plain, dict)
+    assert plain["service"]["name"] == "nautodog"
+    assert isinstance(plain["database"], dict)


### PR DESCRIPTION
## Summary
- add a configuration package that exposes a singleton YAML loader with reload support, dot-path access (including list indices), missing-key tracking, and printing helpers
- document the configuration manager usage and outline additional recommended enhancements
- add focused unit tests and a sample YAML file to validate initialization, retrieval, reload, and conversion behaviours

## Testing
- pytest tests/test_config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68da52833b388323ad6240d7f58beacb